### PR TITLE
chore: move null handling to CovSource constructor

### DIFF
--- a/lib/source.js
+++ b/lib/source.js
@@ -3,7 +3,8 @@ const { GREATEST_LOWER_BOUND, LEAST_UPPER_BOUND } = require('source-map').Source
 
 module.exports = class CovSource {
   constructor (sourceRaw, wrapperLength) {
-    sourceRaw = sourceRaw.trimEnd()
+    // Treat null sourceRaw as the empty string
+    sourceRaw = sourceRaw ? sourceRaw.trimEnd() : ''
     this.lines = []
     this.eof = sourceRaw.length
     this.shebangLength = getShebangLength(sourceRaw)

--- a/lib/v8-to-istanbul.js
+++ b/lib/v8-to-istanbul.js
@@ -51,7 +51,6 @@ module.exports = class V8ToIstanbul {
     if (this.rawSourceMap) {
       if (this.rawSourceMap.sourcemap.sources.length > 1) {
         this.sourceMap = await new SourceMapConsumer(this.rawSourceMap.sourcemap)
-        // https://github.com/istanbuljs/v8-to-istanbul/issues/166
         if (!this.sourceMap.sourcesContent) {
           const fileList = this.sourceMap.sources.map(relativePath => {
             const realPath = this._resolveSource(this.rawSourceMap, relativePath)
@@ -61,16 +60,7 @@ module.exports = class V8ToIstanbul {
           })
           this.sourceMap.sourcesContent = await Promise.all(fileList)
         }
-
-        this.covSources = this.sourceMap.sourcesContent.map((rawSource, i) => {
-          if (!rawSource) {
-            return null
-          }
-          if (this.excludePath(this.sourceMap.sources[i])) {
-            return null
-          }
-          return ({ source: new CovSource(rawSource, this.wrapperLength), path: this.sourceMap.sources[i] })
-        }).filter(covSource => covSource)
+        this.covSources = this.sourceMap.sourcesContent.map((rawSource, i) => ({ source: new CovSource(rawSource, this.wrapperLength), path: this.sourceMap.sources[i] }))
         this.sourceTranspiled = new CovSource(rawSource, this.wrapperLength)
       } else {
         const candidatePath = this.rawSourceMap.sourcemap.sources.length >= 1 ? this.rawSourceMap.sourcemap.sources[0] : this.rawSourceMap.sourcemap.file

--- a/test/source.js
+++ b/test/source.js
@@ -38,6 +38,11 @@ describe('Source', () => {
       const source = new CovSource(sourceRaw, 0)
       source.offsetToOriginalRelative(undefined, Infinity, Infinity).should.deepEqual({})
     })
+
+    it('accepts null', () => {
+      const sourceRaw = null
+      new CovSource(sourceRaw, 0).should.ok()
+    })
   })
 
   describe('ignore', () => {


### PR DESCRIPTION
This implements `2-ii` in https://github.com/istanbuljs/v8-to-istanbul/pull/168#issuecomment-968693185 to fix the coverage failure, that probably @bcoe worries about. -)